### PR TITLE
Makefile update

### DIFF
--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -80,6 +80,7 @@ endif
 getlibs: .mbed
 
 .mbed:
+	touch .mbed
 	mbed config root .
 	mbed toolchain GCC_ARM
 	mbed target $(BOARD)


### PR DESCRIPTION
I tried to build jerryscript for mbed os 5, but I faced an build error shown below:

<pre>
mbed config root .
[mbed] ERROR: Could not find mbed program in current path "C:\work\RZA1\mbed\work\jerryscript\targets\mbedos5".
[mbed] ERROR: Change the current directory to a valid mbed program or use the '--global' option to set global configuration.
</pre>

It is thought that the cause of issue is the lack of _.mbed_ file in jerryscript\targets\mbedos5. If **_touch .mbed_** was added to Makefile, I could build jerryscript.